### PR TITLE
Some small changes to missing auras highlights for consistency

### DIFF
--- a/config/Spells.lua
+++ b/config/Spells.lua
@@ -316,14 +316,14 @@ function private.GetSpellOptions(addon, addonName)
 				type = 'select',
 				values = {
 						none = L['Disabled'],
-						invert = L['Invert border'],
+						invert = L['Show border'],
 						flash = L['Show flash'],
 						hint = L['Show hint'],
 				},
 				set = function(info, value)
 					handler:Set(info, value)
-					if value ~= 'none' and value ~= 'invert' then
-						addon.db.profile.flashPromotion[handler.current] = false
+					if value ~= 'none' then
+						addon.db.profile.flashPromotion[handler.current] = nil
 					end
 				end,
 			},
@@ -334,7 +334,7 @@ function private.GetSpellOptions(addon, addonName)
 				type = 'toggle',
 				width = 'double',
 				disabled = function()
-					return addon.db.profile.missing[handler.current] ~= 'none' and addon.db.profile.missing[handler.current] ~= 'invert'
+					return addon.db.profile.missing[handler.current] ~= 'none'
 				end,
 			},
 			rules = {

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -234,13 +234,18 @@ function addon:ADDON_LOADED(event, name)
 
 		self.db = GetLib('AceDB-3.0'):New(addonName.."DB", self.DEFAULT_SETTINGS, true)
 
-		if self.db.profile.inverted then
-			for key, inverted in pairs(self.db.profile.inverted) do
-				if inverted then
-					self.db.profile.missing[key] = "invert"
+		-- migrate SV from old inverted to new missing
+		local profile = self.db.profile
+		if profile.inverted then
+			for key in pairs(profile.inverted) do
+				if profile.flashPromotion[key] then
+					profile.missing[key] = "flash"
+					profile.flashPromotion[key] = nil
+				else
+					profile.missing[key] = "invert"
 				end
 			end
-			self.db.profile.inverted = nil
+			profile.inverted = nil
 		end
 
 		self.db.RegisterCallback(self, "OnProfileChanged")


### PR DESCRIPTION
With your changes you leave two ways to have a flash highlight for missing auras:
  1. Select `Show flash`
  2. Select `Invert border` and check `Show flash instead`

May I offer a fix for that? Do you think it keeps consistency with the current behavior of `Show flash instead`?